### PR TITLE
Add is_wasteful metric

### DIFF
--- a/xbpgh_sim/levels.py
+++ b/xbpgh_sim/levels.py
@@ -436,6 +436,7 @@ LEVELS = [
                 [False, False, False, False],
             ],
         ),
+        theoretical_min_waste=2,
     ),
     Level(
         level_id=10,
@@ -820,6 +821,7 @@ LEVELS = [
                 [False, False, False, False],
             ],
         ),
+        theoretical_min_waste=3,
     ),
     Level(
         level_id=19,
@@ -868,6 +870,7 @@ LEVELS = [
                 [True, False, False, True],
             ],
         ),
+        theoretical_min_waste=2,
     ),
     Level(
         level_id=20,
@@ -1252,6 +1255,7 @@ LEVELS = [
                 [False, True, True, False],
             ],
         ),
+        theoretical_min_waste=1,
     ),
     Level(
         level_id=28,

--- a/xbpgh_sim/models.py
+++ b/xbpgh_sim/models.py
@@ -367,6 +367,12 @@ class Level:
 
     target_state: State
 
+    # Theoretical min waste: for levels with at least 2 connected components of
+    # cells, there must be at least one waste cell either adjacent to or inside
+    # each connected component. The theoretical min waste is the minimum size
+    # of such a covering set.
+    theoretical_min_waste: int = 0
+
     can_place_metal: bool = False
 
 
@@ -378,6 +384,7 @@ class Metrics:
     num_frames: int
     is_stable: bool
     num_waste: int
+    is_wasteful: bool
 
 
 @dataclass

--- a/xbpgh_sim/simulator.py
+++ b/xbpgh_sim/simulator.py
@@ -179,6 +179,10 @@ def simulate_solution(level: Level, solution: Solution) -> SimulationResult:
     final_state.live_cells = None
     is_correct = final_state == level.target_state
 
+    is_wasteful = num_waste > level.theoretical_min_waste
+    if is_correct:
+        assert num_waste >= level.theoretical_min_waste
+
     return SimulationResult(
         level=level,
         solution=solution,
@@ -192,5 +196,6 @@ def simulate_solution(level: Level, solution: Solution) -> SimulationResult:
             num_frames=num_frames,
             is_stable=is_stable,
             num_waste=num_waste,
+            is_wasteful=is_wasteful,
         ),
     )


### PR DESCRIPTION
This compares solution waste to the theoretical min waste. The theoretical min waste is nonzero only when the level has at least 2 connected components, and equals the minimum set of waste cells necessary so that each connected component either contains a waste cell or is adjacent to a waste cell. In particular, it is nonzero for:
```
3-3: theoretical_min_waste = 2
Bonus 1-2 A. Zuri: theoretical_min_waste = 3
Bonus 1-3 M. Lang: theoretical_min_waste = 2
Bonus 4-2 J. Li: theoretical_min_waste = 1
```
(Note that for all levels, theoretical mins have been achieved, so these are actually also the practical minimum waste.)